### PR TITLE
2024.6くらいまでのライブラリを更新する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,10 @@
 .gradle
 /local.properties
 /.idea/caches
+/.idea/.name
+/.idea/codeStyles
 /.idea/libraries
+/.idea/other.xml
 /.idea/modules.xml
 /.idea/workspace.xml
 /.idea/navEditor.xml

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,16 +1,16 @@
 [versions]
 agp = "8.5.0"
 coilCompose = "2.6.0"
-junitJupiter = "5.10.0"
+junitJupiter = "5.10.2"
 kotlin = "1.9.0"
 coreKtx = "1.13.1"
 junit = "4.13.2"
-junitVersion = "1.1.5"
-espressoCore = "3.5.1"
-lifecycleRuntimeKtx = "2.8.1"
+junitVersion = "1.2.1"
+espressoCore = "3.6.1"
+lifecycleRuntimeKtx = "2.8.3"
 activityCompose = "1.9.0"
-composeBom = "2024.05.00"
-generativeAI = "0.7.0"
+composeBom = "2024.06.00"
+generativeAI = "0.8.0"
 secretsGradlePlugin = "2.0.1"
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.4.1"
+agp = "8.5.0"
 coilCompose = "2.6.0"
 junitJupiter = "5.10.0"
 kotlin = "1.9.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Jun 10 23:43:41 JST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## 背景
コンスタントなライブラリの更新を実施

## やったこと
- `.idea`配下のgitに含める必要のないファイルをgitignoreに追加する
- agpのバージョンを8.5.0を追加
- 利用ライブラリの更新
  - 大きな変更なさそう