### PR TITLE
GeminiModel名が変更されたので更新

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Build With Gradle
         run: ./gradlew assembleDebug
       - name: UnitTest
-        run: ./gradlew testDebugUnitTest
+        run: ./gradlew test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,4 +27,4 @@ jobs:
       - name: Build With Gradle
         run: ./gradlew assembleDebug
       - name: UnitTest
-        run: ./gradlew test
+        run: ./gradlew testDebugUnitTest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,8 +14,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.base.sha }}
       - name: Setup JDK
         uses: actions/setup-java@v3
         with:

--- a/app/src/main/java/com/example/cookingidea/model/GeminiModelHelper.kt
+++ b/app/src/main/java/com/example/cookingidea/model/GeminiModelHelper.kt
@@ -7,8 +7,8 @@ import com.google.ai.client.generativeai.type.generationConfig
 object GeminiModelHelper {
 
     enum class ModelType(val modelName: String) {
-        FLASH("gemini-1.5-flash"),
-        PRO("gemini-1.5-pro"),
+        FLASH("models/gemini-1.5-flash"),
+        PRO("models/gemini-1.5-pro"),
     }
 
     enum class ResponseType(val responseMimeType: String) {


### PR DESCRIPTION
## 背景
#7 にてGeminiSDKのバージョンを更新した。
そこでGeminiModel名の更新があり、元のモデル名では利用できなくなった。

#7内でのテストで検知でされるべきであるが、検知はされていなかった。原因は不明

## やったこと
GeminiModelを更新後のものにする