### PR TITLE
PR作成時に自動的にAssigneesを付与する

### DIFF
--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -2,7 +2,7 @@ name: Assign Author
 
 on:
   pull_request:
-    types: [opened, edited]
+    types: [opened, synchronize]
 
 permissions:
   pull-requests: write

--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -2,7 +2,8 @@ name: Assign Author
 
 on:
   pull_request:
-    types: [opened , reopened]
+    types: 
+      - opened
 
 jobs:
   assign-author:

--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -2,12 +2,19 @@ name: Assign Author
 
 on:
   pull_request:
-    types: 
-      - opened
+    types: [opened, edited]
+
+permissions:
+  pull-requests: write
+  repository-projects: read
 
 jobs:
   assign-author:
     runs-on: ubuntu-latest
     steps:
-      - name: Assign author to PR
-        uses: technote-space/assign-author@v1
+      - run: gh pr edit "$PULL_NUMBER" --repo "$REPOSITORY" --add-assignee "$CREATOR"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          PULL_NUMBER: ${{ github.event.pull_request.number }}
+          CREATOR: ${{ github.event.pull_request.user.login }}

--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -2,7 +2,8 @@ name: Assign Author
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types:
+      - opened
 
 permissions:
   pull-requests: write

--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -1,0 +1,13 @@
+name: Assign Author
+
+on:
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign author to PR
+        uses: technote-space/assign-auther@v1

--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -2,12 +2,11 @@ name: Assign Author
 
 on:
   pull_request:
-    types:
-      - opened
+    types: [opened , reopened]
 
 jobs:
   assign-author:
     runs-on: ubuntu-latest
     steps:
       - name: Assign author to PR
-        uses: technote-space/assign-auther@v1
+        uses: technote-space/assign-author@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,9 @@
-name: Pull Request
+name: Build Workflow
 
 on:
+  push:
+    branches:
+      - master
   pull_request:
     types: [ opened, synchronize ]
 


### PR DESCRIPTION
## 背景
テストやlintなどを確認しながら開発を進められるようにワークフローを整備したい。
手始めにPR作成時のAssigneesの自動付与を Github Actions を使用して行う

## やったこと
GithubのAssigneeの付与は、標準でサポートされているのでそれを利用して実装をした
