### PR TITLE
チラシのアップロード画面を作成

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -69,6 +69,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.androidx.material.icon)
     implementation(libs.coil.compose)
     implementation(libs.generative.ai)
     testImplementation(libs.junit)

--- a/app/src/main/java/com/example/cookingidea/ui/screen/main/MainActivity.kt
+++ b/app/src/main/java/com/example/cookingidea/ui/screen/main/MainActivity.kt
@@ -45,6 +45,12 @@ class MainActivity : ComponentActivity() {
                             )
                         )
                     },
+                    onClickFlyerImage = {
+                        // 画像のプレビューに遷移する
+                    },
+                    onClickRemoveImage = {
+                        viewModel.removeSelectedImage()
+                    },
                     onClickGenerator = {
                         loadImage(uiState.selectedImageUri!!)
                     },
@@ -63,16 +69,16 @@ class MainActivity : ComponentActivity() {
         val request = ImageRequest.Builder(this)
             .data(uri)
             .target(
-                onStart = { placeholder ->
-                    // Handle the placeholder drawable.
+                onStart = { _ ->
+                    // NOP
                 },
                 onSuccess = { result ->
                     lifecycleScope.launch {
                         viewModel.execute((result as BitmapDrawable).bitmap)
                     }
                 },
-                onError = { error ->
-                    // Handle the error drawable.
+                onError = { _ ->
+                    // NOP
                 }
             )
             .build()

--- a/app/src/main/java/com/example/cookingidea/ui/screen/main/MainContent.kt
+++ b/app/src/main/java/com/example/cookingidea/ui/screen/main/MainContent.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.example.cookingidea.R
+import com.example.cookingidea.ui.screen.main.compose.EditConditionFlyer
 import com.example.cookingidea.ui.theme.CookingIdeaTheme
 
 @Composable
@@ -46,29 +47,9 @@ fun MainContent(
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
 
-            Text(
-                text = "チラシを参照する",
-                style = MaterialTheme.typography.titleSmall
+            EditConditionFlyer(
+                selectedImageUrl = uiState.selectedImageUri?.toString()
             )
-
-            AsyncImage(
-                model = uiState.selectedImageUri,
-                contentDescription = "selected_image",
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(280.dp)
-                    .background(color = MaterialTheme.colorScheme.surfaceVariant),
-                contentScale = ContentScale.Fit
-            )
-
-            Button(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(48.dp),
-                onClick = onClickSelectImage,
-            ) {
-                Text(text = stringResource(id = R.string.load_flyer_button_title))
-            }
 
             Button(
                 modifier = Modifier

--- a/app/src/main/java/com/example/cookingidea/ui/screen/main/MainContent.kt
+++ b/app/src/main/java/com/example/cookingidea/ui/screen/main/MainContent.kt
@@ -15,12 +15,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import coil.compose.AsyncImage
 import com.example.cookingidea.R
 import com.example.cookingidea.ui.screen.main.compose.EditConditionFlyer
 import com.example.cookingidea.ui.theme.CookingIdeaTheme
@@ -28,9 +25,11 @@ import com.example.cookingidea.ui.theme.CookingIdeaTheme
 @Composable
 fun MainContent(
     uiState: MainUiState,
+    onClickSelectImageButton: () -> Unit,
+    onClickImage: () -> Unit,
+    onClickRemoveImageButton: () -> Unit,
+    onClickGenerator: () -> Unit,
     modifier: Modifier = Modifier,
-    onClickSelectImage: () -> Unit = {},
-    onClickGenerator: () -> Unit = {},
 ) {
 
     Box(
@@ -48,7 +47,10 @@ fun MainContent(
         ) {
 
             EditConditionFlyer(
-                selectedImageUrl = uiState.selectedImageUri?.toString()
+                selectedImageUrl = uiState.selectedImageUri?.toString(),
+                onClickSelectFlyerButton = onClickSelectImageButton,
+                onClickFlyerImage = onClickImage,
+                onClickRemoveFlyerButton = onClickRemoveImageButton,
             )
 
             Button(
@@ -74,6 +76,12 @@ fun MainContent(
 @Composable
 private fun PreviewMainContent() {
     CookingIdeaTheme {
-        MainContent(uiState = MainUiState())
+        MainContent(
+            uiState = MainUiState(),
+            onClickSelectImageButton = {},
+            onClickImage = {},
+            onClickRemoveImageButton = {},
+            onClickGenerator = {},
+        )
     }
 }

--- a/app/src/main/java/com/example/cookingidea/ui/screen/main/MainScreen.kt
+++ b/app/src/main/java/com/example/cookingidea/ui/screen/main/MainScreen.kt
@@ -23,9 +23,11 @@ import com.example.cookingidea.ui.theme.CookingIdeaTheme
 fun MainScreen(
     uiState: MainUiState,
     dialogUiState: MenuDialogUiState,
-    onClickSelectImage: () -> Unit = {},
-    onClickGenerator: () -> Unit = {},
-    onDismissDialogRequest: () -> Unit = {},
+    onClickSelectImage: () -> Unit,
+    onClickFlyerImage: () -> Unit,
+    onClickRemoveImage: () -> Unit,
+    onClickGenerator: () -> Unit,
+    onDismissDialogRequest: () -> Unit,
 ) {
 
     Scaffold(
@@ -46,7 +48,9 @@ fun MainScreen(
             MainContent(
                 modifier = Modifier.padding(it),
                 uiState = uiState,
-                onClickSelectImage = onClickSelectImage,
+                onClickSelectImageButton = onClickSelectImage,
+                onClickImage = onClickFlyerImage,
+                onClickRemoveImageButton = onClickRemoveImage,
                 onClickGenerator = onClickGenerator,
             )
 
@@ -68,6 +72,11 @@ private fun MainScreenPreview() {
         MainScreen(
             uiState = MainUiState(),
             dialogUiState = MenuDialogUiState(),
+            onClickSelectImage = {},
+            onClickFlyerImage = {},
+            onClickRemoveImage = {},
+            onClickGenerator = {},
+            onDismissDialogRequest = {},
         )
     }
 }

--- a/app/src/main/java/com/example/cookingidea/ui/screen/main/MainViewModel.kt
+++ b/app/src/main/java/com/example/cookingidea/ui/screen/main/MainViewModel.kt
@@ -40,6 +40,10 @@ class MainViewModel(private val application: Application) : AndroidViewModel(app
         _uiStateFlow.update { it.copy(showDialog = false) }
     }
 
+    fun removeSelectedImage() {
+        _uiStateFlow.update { it.copy(selectedImageUri = null) }
+    }
+
     suspend fun execute(image: Bitmap) {
 
         _uiStateFlow.update {

--- a/app/src/main/java/com/example/cookingidea/ui/screen/main/compose/EditConditionFlyer.kt
+++ b/app/src/main/java/com/example/cookingidea/ui/screen/main/compose/EditConditionFlyer.kt
@@ -66,7 +66,7 @@ fun EditConditionFlyer(
     showBackground = true
 )
 @Composable
-fun PreviewEditConditionFlyer_empty() {
+private fun PreviewEditConditionFlyer_empty() {
     CookingIdeaTheme {
         EditConditionFlyer(
             selectedImageUrl = null
@@ -78,7 +78,7 @@ fun PreviewEditConditionFlyer_empty() {
     showBackground = true
 )
 @Composable
-fun PreviewEditConditionFlyer_image() {
+private fun PreviewEditConditionFlyer_image() {
     CookingIdeaTheme {
         EditConditionFlyer(
             selectedImageUrl = ""

--- a/app/src/main/java/com/example/cookingidea/ui/screen/main/compose/EditConditionFlyer.kt
+++ b/app/src/main/java/com/example/cookingidea/ui/screen/main/compose/EditConditionFlyer.kt
@@ -19,10 +19,10 @@ import com.example.cookingidea.ui.theme.CookingIdeaTheme
 @Composable
 fun EditConditionFlyer(
     selectedImageUrl: String?,
+    onClickSelectFlyerButton: () -> Unit,
+    onClickFlyerImage: () -> Unit,
+    onClickRemoveFlyerButton: () -> Unit,
     modifier: Modifier = Modifier,
-    onClickSelectFlyer: () -> Unit = {},
-    onClickFlyerImage: () -> Unit = {},
-    onClickRemoveFlyerButton: () -> Unit = {},
 ) {
 
     Column(
@@ -50,7 +50,7 @@ fun EditConditionFlyer(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(48.dp),
-            onClick = onClickSelectFlyer,
+            onClick = onClickSelectFlyerButton,
         ) {
             val buttonTitleRes = if (selectedImageUrl != null) {
                 R.string.edit_flyer_image_button_title
@@ -69,7 +69,10 @@ fun EditConditionFlyer(
 private fun PreviewEditConditionFlyer_empty() {
     CookingIdeaTheme {
         EditConditionFlyer(
-            selectedImageUrl = null
+            selectedImageUrl = null,
+            onClickSelectFlyerButton = {},
+            onClickFlyerImage = {},
+            onClickRemoveFlyerButton = {},
         )
     }
 }
@@ -81,7 +84,10 @@ private fun PreviewEditConditionFlyer_empty() {
 private fun PreviewEditConditionFlyer_image() {
     CookingIdeaTheme {
         EditConditionFlyer(
-            selectedImageUrl = ""
+            selectedImageUrl = "",
+            onClickSelectFlyerButton = {},
+            onClickFlyerImage = {},
+            onClickRemoveFlyerButton = {},
         )
     }
 }

--- a/app/src/main/java/com/example/cookingidea/ui/screen/main/compose/EditConditionFlyer.kt
+++ b/app/src/main/java/com/example/cookingidea/ui/screen/main/compose/EditConditionFlyer.kt
@@ -1,0 +1,87 @@
+package com.example.cookingidea.ui.screen.main.compose
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.example.cookingidea.R
+import com.example.cookingidea.ui.theme.CookingIdeaTheme
+
+@Composable
+fun EditConditionFlyer(
+    selectedImageUrl: String?,
+    modifier: Modifier = Modifier,
+    onClickSelectFlyer: () -> Unit = {},
+    onClickFlyerImage: () -> Unit = {},
+    onClickRemoveFlyerButton: () -> Unit = {},
+) {
+
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Text(
+            text = "チラシを参照する",
+            style = MaterialTheme.typography.titleSmall
+        )
+
+        if (selectedImageUrl != null) {
+            FlyerImage(
+                selectedImageUrl = selectedImageUrl,
+                onClickImage = onClickFlyerImage,
+                onClickRemoveButton = onClickRemoveFlyerButton,
+            )
+        }
+
+        if (selectedImageUrl == null) {
+            Spacer(modifier = Modifier.height(4.dp))
+        }
+
+        Button(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(48.dp),
+            onClick = onClickSelectFlyer,
+        ) {
+            val buttonTitleRes = if (selectedImageUrl != null) {
+                R.string.edit_flyer_image_button_title
+            } else {
+                R.string.load_flyer_button_title
+            }
+            Text(text = stringResource(id = buttonTitleRes))
+        }
+    }
+}
+
+@Preview(
+    showBackground = true
+)
+@Composable
+fun PreviewEditConditionFlyer_empty() {
+    CookingIdeaTheme {
+        EditConditionFlyer(
+            selectedImageUrl = null
+        )
+    }
+}
+
+@Preview(
+    showBackground = true
+)
+@Composable
+fun PreviewEditConditionFlyer_image() {
+    CookingIdeaTheme {
+        EditConditionFlyer(
+            selectedImageUrl = ""
+        )
+    }
+}

--- a/app/src/main/java/com/example/cookingidea/ui/screen/main/compose/EditConditionFlyer.kt
+++ b/app/src/main/java/com/example/cookingidea/ui/screen/main/compose/EditConditionFlyer.kt
@@ -5,7 +5,10 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Upload
 import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -57,7 +60,15 @@ fun EditConditionFlyer(
             } else {
                 R.string.load_flyer_button_title
             }
-            Text(text = stringResource(id = buttonTitleRes))
+
+            Icon(
+                imageVector = Icons.Default.Upload,
+                contentDescription = null
+            )
+
+            Text(
+                text = stringResource(id = buttonTitleRes)
+            )
         }
     }
 }

--- a/app/src/main/java/com/example/cookingidea/ui/screen/main/compose/FlyerImage.kt
+++ b/app/src/main/java/com/example/cookingidea/ui/screen/main/compose/FlyerImage.kt
@@ -1,0 +1,68 @@
+package com.example.cookingidea.ui.screen.main.compose
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.example.cookingidea.ui.theme.CookingIdeaTheme
+
+@Composable
+fun FlyerImage(
+    selectedImageUrl: String,
+    onClickImage: () -> Unit,
+    onClickRemoveButton: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier,
+    ) {
+        AsyncImage(
+            model = selectedImageUrl,
+            contentDescription = "selected_image",
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(240.dp)
+                .background(color = MaterialTheme.colorScheme.surfaceVariant)
+                .clickable {
+                    onClickImage()
+                },
+            contentScale = ContentScale.Fit
+        )
+
+        IconButton(
+            modifier = Modifier
+                .align(Alignment.TopEnd),
+            onClick = { onClickRemoveButton() }
+        ) {
+            Icon(
+                imageVector = Icons.Default.Close,
+                contentDescription = "remove_flyer_image",
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+fun PreviewFlyerImage() {
+    CookingIdeaTheme {
+        FlyerImage(
+            selectedImageUrl = "",
+            onClickImage = {},
+            onClickRemoveButton = {}
+        )
+    }
+}

--- a/app/src/main/java/com/example/cookingidea/ui/screen/main/compose/FlyerImage.kt
+++ b/app/src/main/java/com/example/cookingidea/ui/screen/main/compose/FlyerImage.kt
@@ -36,18 +36,22 @@ fun FlyerImage(
                 .fillMaxWidth()
                 .height(240.dp)
                 .background(color = MaterialTheme.colorScheme.surfaceVariant)
-                .clickable {
-                    onClickImage()
-                },
-            contentScale = ContentScale.Fit
+                .clickable(
+                    onClick = {
+                        onClickRemoveButton()
+                    },
+                    onClickLabel = "open_flyer_preview"
+                ),
+            contentScale = ContentScale.Fit,
         )
 
         IconButton(
             modifier = Modifier
                 .align(Alignment.TopEnd),
-            onClick = { onClickRemoveButton() }
+            onClick = { onClickRemoveButton() },
         ) {
             Icon(
+                modifier = Modifier,
                 imageVector = Icons.Default.Close,
                 contentDescription = "remove_flyer_image",
             )

--- a/app/src/main/java/com/example/cookingidea/ui/screen/main/compose/FlyerImage.kt
+++ b/app/src/main/java/com/example/cookingidea/ui/screen/main/compose/FlyerImage.kt
@@ -57,7 +57,7 @@ fun FlyerImage(
 
 @Preview
 @Composable
-fun PreviewFlyerImage() {
+private fun PreviewFlyerImage() {
     CookingIdeaTheme {
         FlyerImage(
             selectedImageUrl = "",

--- a/app/src/main/java/com/example/cookingidea/ui/screen/main/compose/FlyerImage.kt
+++ b/app/src/main/java/com/example/cookingidea/ui/screen/main/compose/FlyerImage.kt
@@ -38,7 +38,7 @@ fun FlyerImage(
                 .background(color = MaterialTheme.colorScheme.surfaceVariant)
                 .clickable(
                     onClick = {
-                        onClickRemoveButton()
+                        onClickImage()
                     },
                     onClickLabel = "open_flyer_preview"
                 ),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,7 +10,8 @@
     <string name="prompt_condition_use_ingredient">- 添付したチラシ以外で以下の食材を利用すること</string>
     <string name="prompt_condition_use_menu_theme">- 献立のテーマとして、このテーマに則った献立にして下さい『%s』\n</string>
 
-    <string name="load_flyer_button_title">チラシを読み込む</string>
+    <string name="load_flyer_button_title">チラシの写真をアップロードする</string>
+    <string name="edit_flyer_image_button_title">チラシの写真を変更する</string>
     
     <string name="menu_dialog_title">今日の献立</string>
     <string name="start_create_menu_button_title">献立を生成する</string>

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -135,7 +135,7 @@ complexity:
     constructorThreshold: 7
     ignoreDefaultParameters: false
     ignoreDataClasses: true
-    ignoreAnnotatedParameter: [ 'Composable' ]
+    ignoreAnnotated: [ 'Composable' ]
   MethodOverloading:
     active: false
     threshold: 6

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -135,7 +135,7 @@ complexity:
     constructorThreshold: 7
     ignoreDefaultParameters: false
     ignoreDataClasses: true
-    ignoreAnnotatedParameter: [ ]
+    ignoreAnnotatedParameter: [ 'Composable' ]
   MethodOverloading:
     active: false
     threshold: 6

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-material-icon = { group = "androidx.compose.material", name = "material-icons-extended" }
 generative-ai = { group = "com.google.ai.client.generativeai", name = "generativeai", version.ref = "generativeAI" }
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junitJupiter" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junitJupiter" }


### PR DESCRIPTION
## 概要
チラシのアップロード画面をアップデートしたい。
チラシのアップロードする画面を個々のComposable関数に構造化をして、再設計する。

参考にしたfigmaの設計図
<img width="288" alt="スクリーンショット 2024-07-20 15 09 36" src="https://github.com/user-attachments/assets/7fb574e4-1d98-4b6a-a00a-436dd8413668">

## やったこと
- [x] アップロード部分の作成
- [x] MainAcivityに反映されている
- [ ] テストが書かれている