### PR TITLE
Kotlin2.0へのバージョン更新

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.jetbrains.kotlin.android)
+    alias(libs.plugins.compose.compiler)
     id("com.google.android.libraries.mapsplatform.secrets-gradle-plugin")
     id("de.mannodermaus.android-junit5") version "1.10.0.0"
     id("io.gitlab.arturbosch.detekt") version "1.23.6"
@@ -43,9 +44,6 @@ android {
         compose = true
         buildConfig = true
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.1"
-    }
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
@@ -82,5 +80,5 @@ dependencies {
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
 
-    detektPlugins (libs.detekt.compose)
+    detektPlugins(libs.detekt.compose)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,9 @@
 [versions]
-agp = "8.5.0"
+agp = "8.6.0"
 coilCompose = "2.6.0"
 detektCompose = "0.3.3"
 junitJupiter = "5.10.2"
-kotlin = "1.9.0"
+kotlin = "2.0.10"
 coreKtx = "1.13.1"
 junit = "4.13.2"
 junitVersion = "1.2.1"
@@ -42,4 +42,5 @@ secrets-gradle-plugin = { group = "com.google.android.libraries.mapsplatform.sec
 android-application = { id = "com.android.application", version.ref = "agp" }
 jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 secrets-gradle-plugin = { id = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin", version.ref = "secretsGradlePlugin" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 


### PR DESCRIPTION
## 概要
Kotlinのバージョンで2.0 がリリースされているため、それに追従させるためにバージョン更新を行なった。
なお、現在は`2.0.20`がすでにリリースされているが、stop skip modeの確認が不十分なため、一旦Kotlin2.0.0へのバージョン更新を実施した。

## やったこと
- Kotlin2.0への更新
- AGPのバージョン更新